### PR TITLE
Add methods for using postgame data

### DIFF
--- a/Model/EndGameEvent.cs
+++ b/Model/EndGameEvent.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Model;
+
+// Note: This is a point of game-server (private) and public interchange. This class will be created by the private
+// game server and forwarded here for us to use.
+public record class EndGameEvent
+{
+    [SetsRequiredMembers]
+    public EndGameEvent(Guid matchId, DateTimeOffset matchCreationTime, DateTimeOffset matchEndTime, string map, string gameMode, GameEndPlayer[] players)
+    {
+        MatchId = matchId;
+        MatchCreationTime = matchCreationTime;
+        MatchEndTime = matchEndTime;
+        Map = map ?? throw new ArgumentNullException(nameof(map));
+        GameMode = gameMode ?? throw new ArgumentNullException(nameof(gameMode));
+        Players = players ?? throw new ArgumentNullException(nameof(players));
+    }
+
+    public required Guid MatchId { get; set; }
+    public required DateTimeOffset MatchCreationTime { get; set; }
+    public required DateTimeOffset MatchEndTime { get; set; }
+    public required string Map { get; set; }
+    public required string GameMode { get; set; }
+    public required GameEndPlayer[] Players { get; set; }
+
+    public virtual bool Equals(EndGameEvent? @event)
+    {
+        return @event is not null &&
+               EqualityComparer<Type>.Default.Equals(EqualityContract, @event.EqualityContract) &&
+               MatchId.Equals(@event.MatchId) &&
+               MatchCreationTime.Equals(@event.MatchCreationTime) &&
+               MatchEndTime.Equals(@event.MatchEndTime) &&
+               Map == @event.Map &&
+               GameMode == @event.GameMode &&
+               EqualityComparer<GameEndPlayer[]>.Default.Equals(Players, @event.Players);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(EqualityContract, MatchId, MatchCreationTime, MatchEndTime, Map, GameMode, Players);
+    }
+}

--- a/Model/GameEndPlayer.cs
+++ b/Model/GameEndPlayer.cs
@@ -1,0 +1,41 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Model;
+
+public record class GameEndPlayer
+{
+    [SetsRequiredMembers]
+    public GameEndPlayer(Guid playerId, string teamId, bool finishedMatch, GameEndPlayerStats stats, string sponsor, GameEndWeaponStat[] weaponStats)
+    {
+        PlayerId = playerId;
+        TeamId = teamId ?? throw new ArgumentNullException(nameof(teamId));
+        FinishedMatch = finishedMatch;
+        Stats = stats ?? throw new ArgumentNullException(nameof(stats));
+        Sponsor = sponsor ?? throw new ArgumentNullException(nameof(sponsor));
+        WeaponStats = weaponStats ?? throw new ArgumentNullException(nameof(weaponStats));
+    }
+
+    public required Guid PlayerId { get; set; }
+    public required string TeamId { get; set; }
+    public required bool FinishedMatch { get; set; }
+    public required GameEndPlayerStats Stats { get; set; }
+    public required string Sponsor { get; set; }
+    public required GameEndWeaponStat[] WeaponStats { get; set; }
+
+    public virtual bool Equals(GameEndPlayer? player)
+    {
+        return player is not null &&
+               EqualityComparer<Type>.Default.Equals(EqualityContract, player.EqualityContract) &&
+               PlayerId.Equals(player.PlayerId) &&
+               TeamId == player.TeamId &&
+               FinishedMatch == player.FinishedMatch &&
+               EqualityComparer<GameEndPlayerStats>.Default.Equals(Stats, player.Stats) &&
+               Sponsor == player.Sponsor &&
+               EqualityComparer<GameEndWeaponStat[]>.Default.Equals(WeaponStats, player.WeaponStats);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(EqualityContract, PlayerId, TeamId, FinishedMatch, Stats, Sponsor, WeaponStats);
+    }
+}

--- a/Model/GameEndPlayerStats.cs
+++ b/Model/GameEndPlayerStats.cs
@@ -1,0 +1,106 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Model;
+
+public class GameEndPlayerStats : IEquatable<GameEndPlayerStats?>
+{
+    [SetsRequiredMembers]
+    public GameEndPlayerStats(long killCount, long deathCount, long aceCount, long dualityKillCount, long firstKillCount, long firstDeathCount, double kAST, double dualityRating, long assistCount, long tradeCount, double impactCount, long winCount, long roundsPlayed, long roundsSurvived, long numHeadshots, long numDamagingShots, long totalDamage)
+    {
+        KillCount = killCount;
+        DeathCount = deathCount;
+        AceCount = aceCount;
+        DualityKillCount = dualityKillCount;
+        FirstKillCount = firstKillCount;
+        FirstDeathCount = firstDeathCount;
+        KAST = kAST;
+        DualityRating = dualityRating;
+        AssistCount = assistCount;
+        TradeCount = tradeCount;
+        ImpactCount = impactCount;
+        WinCount = winCount;
+        RoundsPlayed = roundsPlayed;
+        RoundsSurvived = roundsSurvived;
+        NumHeadshots = numHeadshots;
+        NumDamagingShots = numDamagingShots;
+        TotalDamage = totalDamage;
+    }
+
+    public required Int64 KillCount { get; set; }
+    public required Int64 DeathCount { get; set; }
+    public required Int64 AceCount { get; set; }
+    public required Int64 DualityKillCount { get; set; }
+    public required Int64 FirstKillCount { get; set; }
+    public required Int64 FirstDeathCount { get; set; }
+    public required double KAST { get; set; }
+    public required double DualityRating { get; set; }
+    public required Int64 AssistCount { get; set; }
+    public required Int64 TradeCount { get; set; }
+    public required double ImpactCount { get; set; }
+    public required Int64 WinCount { get; set; }
+    public required Int64 RoundsPlayed { get; set; }
+    public required Int64 RoundsSurvived { get; set; }
+    public required Int64 NumHeadshots { get; set; }
+    public required Int64 NumDamagingShots { get; set; }
+    public required Int64 TotalDamage { get; set; }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as GameEndPlayerStats);
+    }
+
+    public bool Equals(GameEndPlayerStats? other)
+    {
+        return other is not null &&
+               KillCount == other.KillCount &&
+               DeathCount == other.DeathCount &&
+               AceCount == other.AceCount &&
+               DualityKillCount == other.DualityKillCount &&
+               FirstKillCount == other.FirstKillCount &&
+               FirstDeathCount == other.FirstDeathCount &&
+               KAST == other.KAST &&
+               DualityRating == other.DualityRating &&
+               AssistCount == other.AssistCount &&
+               TradeCount == other.TradeCount &&
+               ImpactCount == other.ImpactCount &&
+               WinCount == other.WinCount &&
+               RoundsPlayed == other.RoundsPlayed &&
+               RoundsSurvived == other.RoundsSurvived &&
+               NumHeadshots == other.NumHeadshots &&
+               NumDamagingShots == other.NumDamagingShots &&
+               TotalDamage == other.TotalDamage;
+    }
+
+    public override int GetHashCode()
+    {
+        HashCode hash = new HashCode();
+        hash.Add(KillCount);
+        hash.Add(DeathCount);
+        hash.Add(AceCount);
+        hash.Add(DualityKillCount);
+        hash.Add(FirstKillCount);
+        hash.Add(FirstDeathCount);
+        hash.Add(KAST);
+        hash.Add(DualityRating);
+        hash.Add(AssistCount);
+        hash.Add(TradeCount);
+        hash.Add(ImpactCount);
+        hash.Add(WinCount);
+        hash.Add(RoundsPlayed);
+        hash.Add(RoundsSurvived);
+        hash.Add(NumHeadshots);
+        hash.Add(NumDamagingShots);
+        hash.Add(TotalDamage);
+        return hash.ToHashCode();
+    }
+
+    public static bool operator ==(GameEndPlayerStats? left, GameEndPlayerStats? right)
+    {
+        return EqualityComparer<GameEndPlayerStats>.Default.Equals(left, right);
+    }
+
+    public static bool operator !=(GameEndPlayerStats? left, GameEndPlayerStats? right)
+    {
+        return !(left == right);
+    }
+}

--- a/Model/GameEndWeaponStat.cs
+++ b/Model/GameEndWeaponStat.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Model;
+
+public class GameEndWeaponStat : IEquatable<GameEndWeaponStat?>
+{
+    [SetsRequiredMembers]
+    public GameEndWeaponStat(string weaponId, long weaponKillCount)
+    {
+        WeaponId = weaponId ?? throw new ArgumentNullException(nameof(weaponId));
+        WeaponKillCount = weaponKillCount;
+    }
+
+    public required string WeaponId { get; set; }
+    public required Int64 WeaponKillCount { get; set; }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as GameEndWeaponStat);
+    }
+
+    public bool Equals(GameEndWeaponStat? other)
+    {
+        return other is not null &&
+               WeaponId == other.WeaponId &&
+               WeaponKillCount == other.WeaponKillCount;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(WeaponId, WeaponKillCount);
+    }
+
+    public static bool operator ==(GameEndWeaponStat? left, GameEndWeaponStat? right)
+    {
+        return EqualityComparer<GameEndWeaponStat>.Default.Equals(left, right);
+    }
+
+    public static bool operator !=(GameEndWeaponStat? left, GameEndWeaponStat? right)
+    {
+        return !(left == right);
+    }
+}

--- a/Model/GameEvents.cs
+++ b/Model/GameEvents.cs
@@ -9,5 +9,11 @@
 
 public class GameEvents
 {
-    public event EventHandler<EndGameEvent>? GameEnd;
+    public static event EventHandler<EndGameEvent>? GameEnd;
+
+    public static void SendGameEndEvent(EndGameEvent evtData)
+    {
+        ArgumentNullException.ThrowIfNull(evtData);
+        GameEnd?.Invoke(null, evtData);
+    }
 }

--- a/Model/GameEvents.cs
+++ b/Model/GameEvents.cs
@@ -1,0 +1,13 @@
+﻿namespace Model;
+
+/*
+ * This is the place to subscribe to events surrounding the game where the private and public sections of code intersect.
+ * Each subsystem that needs to access these events should subscribe themselves to the corresponding events
+ * The code that calls these events is not public as it interacts with the gameserver, but the extracted data structures can be made public
+ * Events will be added to this section as we learn how to save and extract more data from the game.
+ */
+
+public class GameEvents
+{
+    public event EventHandler<EndGameEvent>? GameEnd;
+}

--- a/Processors/Processors/SavePlayerDataProcessor.cs
+++ b/Processors/Processors/SavePlayerDataProcessor.cs
@@ -53,7 +53,7 @@ public class SavePlayerDataProcessor : WebsocketPacketProcessor, IWebsocketPacke
         }
     }
 
-    private static async Task<SpectreWebsocketMessage> ProcessSave(SpectreWebsocketRequest Packet)
+    public static async Task<SpectreWebsocketMessage> ProcessSave(SpectreWebsocketRequest Packet)
     {
         JsonNode dataNode = Packet.RequestPayload["data"] ?? throw new InvalidDataException("SavePlayerData request had no data field");
         string innerJson = dataNode.GetValueKind() == JsonValueKind.String ? dataNode.GetValue<string>() : dataNode.ToJsonString();

--- a/Processors/SpectreWebsocketRequest.cs
+++ b/Processors/SpectreWebsocketRequest.cs
@@ -34,6 +34,11 @@ public record class SpectreWebsocketRequest
 
     public T GetPayloadAsMessage<T>() where T : class, IMessage<T>, new()
     {
-        return TolerantParser.Parse<T>(RequestPayload.ToJsonString());
+        return GetPayloadAsMessage<T>(RequestPayload.ToJsonString());
+    }
+
+    public static T GetPayloadAsMessage<T>(string jsonString) where T : class, IMessage<T>, new()
+    {
+        return TolerantParser.Parse<T>(jsonString);
     }
 }


### PR DESCRIPTION
1. Adds a EndGameEvent class that outlines all the data the pragma server will receive from the game server when the game ends
2. Adds GameEvents which is a way for subsystems like crews and matchmaking to subscribe to these events and then do things based on the data
This is necessary for crews and matchmaking to work properly