### PR TITLE
Crew rpcs

### DIFF
--- a/BackendServer/BackendServer.csproj
+++ b/BackendServer/BackendServer.csproj
@@ -7,10 +7,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>$(DefineConstants);DO_RPC_TRACER;DO_TICKET_BYPASS</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>$(DefineConstants);DO_TICKET_BYPASS;DO_RPC_TRACER</DefineConstants>
   </PropertyGroup>

--- a/Packets/Crew/CrewInfo.proto
+++ b/Packets/Crew/CrewInfo.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package Packets;
+
+message CrewInfo {
+	string crewId = 1;
+	CrewStatus status = 2;
+	string homeTurf = 3;
+	double spotlightStartHour = 4;
+	string spotlightDurationTimeMinutes = 5;
+	string createdDate = 6;
+	string updatedDate = 7;
+	double competitionCount = 8;
+}

--- a/Packets/Crew/CrewInfo.proto
+++ b/Packets/Crew/CrewInfo.proto
@@ -4,11 +4,11 @@ package Packets;
 
 message CrewInfo {
 	string crewId = 1;
-	CrewStatus status = 2;
+	string status = 2;
 	string homeTurf = 3;
-	double spotlightStartHour = 4;
+	int32 spotlightStartHour = 4;
 	string spotlightDurationTimeMinutes = 5;
 	string createdDate = 6;
 	string updatedDate = 7;
-	double competitionCount = 8;
+	int32 competitionCount = 8;
 }

--- a/Packets/Crew/CrewLeagueInfo.proto
+++ b/Packets/Crew/CrewLeagueInfo.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package Packets;
+
+message CrewLeagueInfo {
+	string leagueId = 1;
+	double leagueNameIdx = 2;
+	int32 status = 3; // TODO find names for enum members
+}

--- a/Packets/Crew/CrewPerformanceData.proto
+++ b/Packets/Crew/CrewPerformanceData.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+import "MatchCrewPointData.proto";
+
+package Packets;
+
+message CrewPerformanceData {
+	CrewPerformanceDataWeek currentWeekData = 1;
+	CrewPerformanceDataWeek previousWeekData = 2;
+}
+
+message CrewPerformanceDataWeek {
+	double totalFilledPlayerPointsSlotCount = 1;
+	string totalPlayerPointScore = 2;
+	repeated MatchCrewPointData wildcardPointsData = 3;
+	double totalCrewMatchesPlayedCount = 4;
+	double crewRosterCount = 5;
+}

--- a/Packets/Crew/CrewRankLeaderboardRow.proto
+++ b/Packets/Crew/CrewRankLeaderboardRow.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package Packets;
+
+message CrewRankLeaderboardRow {
+	double rank = 1;
+	string crewId = 2;
+	string weeklyPoints = 3;
+}

--- a/Packets/Crew/DivisionInfo.proto
+++ b/Packets/Crew/DivisionInfo.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package Packets;
+
+message DivisionInfo {
+	string divisionId = 1;
+	string divisionName = 2;
+	int32 divisionType = 3; // This is prob an enum todo name values
+}

--- a/Packets/Crew/DivisionRules.proto
+++ b/Packets/Crew/DivisionRules.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package Packets;
+
+message DivisionRules {
+	double divisionThreshold = 1;
+	double playerScoresCount = 2;
+	double wildcardScoresCount = 3;
+}

--- a/Packets/Crew/GetDashboardData.proto
+++ b/Packets/Crew/GetDashboardData.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+import "CrewInfo.proto";
+import "DivisionInfo.proto";
+import "DivisionRules.proto";
+import "CrewRankLeaderboardRow.proto";
+import "MatchCrewPointData.proto";
+import "CrewPerformanceData.proto";
+import "CrewLeagueInfo.proto";
+
+package Packets;
+
+message GetCrewDashboardDataResponse {
+	string nextAutomationDate = 1;
+	CrewDashboardData crewDashboardData = 2;
+}
+
+message CrewDashboardData {
+	string crewId = 1;
+	CrewInfo crewInfo = 2;
+	DivisionInfo divisionInfo = 3;
+	DivisionRules divisionRules = 4;
+	repeated CrewRankLeaderboardRow rankLeaderboardRecords = 5;
+	repeated MatchCrewPointData playerPoints = 6;
+	repeated MatchCrewPointData wildcardPoints = 7;
+	repeated MatchCrewPointData uncontributedPoints = 8;
+	CrewPerformanceData performanceData = 9;
+	bool crewLocked = 10;
+	CrewLeagueInfo leagueInfo = 11;
+}

--- a/Packets/Crew/GetMatchesPlayedResponse.proto
+++ b/Packets/Crew/GetMatchesPlayedResponse.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package Packets;
+
+message GetNoneCrewMatchesPlayedCountResponse {
+	bool success = 1;
+	double noneCrewMatchesPlayedCount = 2;
+	double gamesRequiredToJoinCrewCount = 3;
+}

--- a/Packets/Crew/MatchCrewPointData.proto
+++ b/Packets/Crew/MatchCrewPointData.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package Packets;
+
+message MatchCrewPointData {
+	string playerId = 1;
+	string matchId = 2;
+	double playerPoints = 3;
+	bool isSpotlightHourMatch = 4;
+	double crewMembersOnTeamCount = 5;
+}


### PR DESCRIPTION
This is basically just a branch that will eventually have all the crew RPCs implemented in here. crews are very entangled with divisions and leagues so implementing this fully will probably take a while. Work should be done in individual branches and then merged into this. Those PRs should link and close the issues of the features they implement. This PR will also have all the design docs and such for the system.
Closes https://github.com/SpectreRevival/PragmaBackend/issues/22

Main tasks:

 Synthesize packet captures into protobuf packet types
 (GS) RE player score calculation and send it through to the backend
 On backend correctly process post-match history
 Create Model types for crew data
 Implement RPCs