### PR TITLE
add event for when match history data is recorded for future use

### DIFF
--- a/Model/GameEvents.cs
+++ b/Model/GameEvents.cs
@@ -10,10 +10,17 @@
 public class GameEvents
 {
     public static event EventHandler<EndGameEvent>? GameEnd;
+    public static event EventHandler<MatchHistoryData>? MatchHistoryRecorded;
 
     public static void SendGameEndEvent(EndGameEvent evtData)
     {
         ArgumentNullException.ThrowIfNull(evtData);
         GameEnd?.Invoke(null, evtData);
+    }
+
+    public static void SendMatchHistoryRecordedEvent(MatchHistoryData evtData)
+    {
+        ArgumentNullException.ThrowIfNull(evtData);
+        MatchHistoryRecorded?.Invoke(null, evtData);
     }
 }


### PR DESCRIPTION
Adds event for when a new match is recorded in the match history. Will probably be used later to recompute stats / rank after a match finishes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>